### PR TITLE
Disable custom home page

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -1,18 +1,3 @@
----
-template: templates/home-page-2.html
----
-
-<div class="container cHeaderTop cHomeContainer">
-       <div class="row">
-          <div class="col-sm-12 col-md-12 col-lg-12">
-          <h1>Welcome to the Devant Learning Portal</h1>
-          </div>
-          <div class="col-sm-12 col-md-6 col-lg-6">
-             <p><b>Note</b><br/>The Home page will be designed to  provide a guided experience to any user coming to docs with a valid Devant use case.<br/> We intend to <b>ONLY INCLUDE</b> conceptual information in the documentation  for the relevant topics and **NOT INCLUDE** any how to guides, or instructions with the exception of Tutorials.</p>
-          </div>
-          <div class="col-sm-12 col-md-6 col-lg-6">
-            <iframe width="800" height="250" src="https://www.youtube.com/embed/65cXAAyeJX0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-          </div>
-       </div>
-</div>
-
+<script>
+  window.location.href = 'what-is-devant';
+</script>


### PR DESCRIPTION
## Purpose
Since we won't be having much content before the con to have a custom home page, `What is devant page` is set as the landing page of the docs site. Users can see all the contents in the left nav.

![Screenshot 2025-03-14 at 09 48 58](https://github.com/user-attachments/assets/050422dc-9f8e-4af1-b60a-a0d0de34ff79)

Created issue to track this #25

## Fixes #24
