### PR TITLE
fix: Enable GLightbox for Image Zoom in Devant Documentation

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -185,6 +185,7 @@ plugins:
     - search:
         lang: ['en']
     - open-in-new-tab
+    - glightbox
     - markdownextradata
 
     - exclude:


### PR DESCRIPTION
## Purpose
Resolves #171 

Images within the Devant documentation are currently static and do not open in a zoomed overlay when clicked, making it difficult to view detailed diagrams or screenshots.

## Goals
Enable the GLightbox plugin to restore image zooming and lightbox overlay functionality across the documentation site, improving readability and user experience.

## Approach
Added the `glightbox` plugin under the `plugins` list in the `mkdocs.yml` configuration file. This instructs the Material for MkDocs theme to initialize the lightbox script for all standard Markdown images.

## User Stories
- As a documentation reader, I want to click on images to view them in a larger, full-screen overlay so that I can clearly read text and examine details within architectural diagrams or UI screenshots.

## Release Note
Fixed an issue where documentation images were not opening in a lightbox overlay by enabling the GLightbox MkDocs plugin.

## Documentation
N/A - This PR itself is a fix applied to the documentation site's infrastructure and does not change the core product documentation content.

## Training
N/A

## Certification
N/A - This is a UI fix for the documentation website and does not impact certification exams.

## Marketing
N/A

## Automation Tests

**Unit Tests**  
N/A - Documentation configuration change.

**Integration Tests**  
N/A - Documentation configuration change.

## Security Checks
- Followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)  
- Ran FindSecurityBugs plugin and verified report? N/A (Not applicable for MkDocs configuration files)  
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test Environment
Tested locally using `mkdocs serve` to verify image click behavior.  

## Learning
Researched the Material for MkDocs theme documentation regarding image zoom support and identified that the native `glightbox` plugin needed to be explicitly declared in the configuration to function properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled glightbox plugin to provide lightbox functionality for images and galleries in documentation, allowing users to view content in an enhanced, interactive modal view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->