### PR TITLE
Add Ballerina config variable naming convention note

### DIFF
--- a/en/docs/devops-and-ci-cd/manage-configurations-and-secrets.md
+++ b/en/docs/devops-and-ci-cd/manage-configurations-and-secrets.md
@@ -56,6 +56,9 @@ To add environment variables:
     !!!tip
         You can optionally import environment variables from a `.env` file by clicking **Import from .env file**.
 
+    !!!info "Note"
+        If you're setting a value for a Ballerina [configurable variable](https://ballerina.io/learn/provide-values-to-configurable-variables/), use the naming convention `BAL_CONFIG_VAR_key=value`.
+
 7. Click **Create**.
 
 ### Add a file mount to your container


### PR DESCRIPTION
## Summary

Fixes #158.

The "Add an environment variable to your container" section didn't mention the naming convention required for Ballerina configurable variables, so users setting these via environment variables had no guidance on the expected key format.

## Change

Added a note after the existing `.env` file import tip, explaining that Ballerina [configurable variables](https://ballerina.io/learn/provide-values-to-configurable-variables/) should use the `BAL_CONFIG_VAR_key=value` naming convention, as requested in the issue.

## Test plan

- [x] Confirmed the new note is inserted in the correct location and uses the same admonition formatting (`!!!info "Note"`) as the rest of the document.
